### PR TITLE
Deprication Fix

### DIFF
--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -3,7 +3,7 @@
 // Package: https://github.com/BCJTI/ng2-cookies
 
 import { Injectable, Inject } from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable()
 export class CookieService {


### PR DESCRIPTION
Angular 5 announces the deprication of DOCUMENT in @angular/platform-browser and says to import from @angular/common instead. This change is small, but it helps to ensure that this cookie service remains current as future versions are released.